### PR TITLE
Better cli arguments parser

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dogtools/dog/types"
+)
+
+type userArgs struct {
+	help        bool
+	version     bool
+	printFooter bool
+	taskName    string
+	taskArgs    []string
+}
+
+var knownFlags = [...]string{
+	"--help", "-h",
+	"--version", "-v",
+	"--footer", "--no-footer",
+}
+
+func printVersion() {
+	fmt.Println("dog version: " + version)
+}
+
+func printHelp() {
+	fmt.Println(`Usage: dog
+       dog [OPTIONS] TASK [ARGS]
+       dog [--help] [--version]
+
+Dog is a command line application that executes tasks.
+
+Options:
+
+  --footer       Print information footer after task execution (default)
+  --no-footer    Don't print information footer after task execution
+  -h, --help     Print this help
+  -v, --version  Print version information and quit`)
+}
+
+func printNoValidDogfile() {
+	fmt.Println(`Error: No valid Dogfile in current directory
+Need help? --> dog --help
+More info  --> https://github.com/dogtools/dog`)
+}
+
+func printTasks(tm types.TaskMap) {
+	maxCharSize := 0
+
+	for taskName, _ := range tm {
+		if len(taskName) > maxCharSize {
+			maxCharSize = len(taskName)
+		}
+	}
+
+	for taskName, t := range tm {
+		spaces := strings.Repeat(" ", maxCharSize-len(taskName)+2)
+		fmt.Printf("%s%s%s\n", taskName, spaces, t.Description)
+	}
+}
+
+func parseArgs(args []string) (a userArgs, err error) {
+
+	// default values
+	a = userArgs{
+		help:        false,
+		version:     false,
+		printFooter: true,
+		taskName:    "",
+		taskArgs:    []string{},
+	}
+
+	// iterate over all provided arguments
+	for i, arg := range args {
+
+		if arg == "--help" || arg == "-h" {
+			if i == 0 && len(args) == 1 && a.taskName == "" {
+				a.help = true
+				return a, nil
+			} else {
+				return a, fmt.Errorf("Error: --help doesn't accept additional parameters")
+			}
+		}
+
+		if arg == "--version" || arg == "-v" {
+			if i == 0 && len(args) == 1 && a.taskName == "" {
+				a.version = true
+				return a, nil
+			} else {
+				return a, fmt.Errorf("Error: --version doesn't accept additional parameters")
+			}
+		}
+
+		if arg == "--footer" {
+			if a.taskName == "" {
+				a.printFooter = true
+			} else {
+				return a, fmt.Errorf("Error: --footer is not a valid task argument")
+			}
+		}
+
+		if arg == "--no-footer" {
+			if a.taskName == "" {
+				a.printFooter = false
+			} else {
+				return a, fmt.Errorf("Error: --no-footer is not a valid task argument")
+			}
+		}
+
+		if string(arg[0]) != "-" {
+			if a.taskName == "" {
+				a.taskName = arg
+			} else {
+				return a, fmt.Errorf("Error: only one task can be executed at a time")
+			}
+		} else {
+			validArg := false
+			for _, f := range knownFlags {
+				if arg == f {
+					validArg = true
+				}
+			}
+			if !validArg {
+				return a, fmt.Errorf("Error: %s is not a valid argument", arg)
+			}
+		}
+	}
+
+	return a, nil
+}

--- a/main.go
+++ b/main.go
@@ -3,70 +3,46 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/dogtools/dog/execute"
 	"github.com/dogtools/dog/parser"
-	"github.com/dogtools/dog/types"
 )
 
-func printHelp() {
-	// TODO write the Help text
-	fmt.Println("Dog Help")
-}
-
-func printTasks(tm types.TaskMap) {
-	maxCharSize := 0
-
-	for taskName, _ := range tm {
-		if len(taskName) > maxCharSize {
-			maxCharSize = len(taskName)
-		}
-	}
-
-	for taskName, t := range tm {
-		spaces := strings.Repeat(" ", maxCharSize-len(taskName)+2)
-		fmt.Printf("%s%s%s\n", taskName, spaces, t.Description)
-	}
-}
+const version = "0.0"
 
 func main() {
-	switch {
 
-	// dog
-	case len(os.Args) == 1:
-		tm, err := parser.LoadDogFile()
-		if err != nil {
-			fmt.Println("Error: No valid Dogfile in current directory")
-			fmt.Println("Need help? --> dog help")
-			fmt.Println("More info ---> https://github.com/dogtools/dog")
-		} else {
-			printTasks(tm)
-		}
-		os.Exit(0)
+	a, err := parseArgs(os.Args[1:])
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
-	// dog help
-	case len(os.Args) == 2 && os.Args[1] == "help":
+	if a.help {
 		printHelp()
 		os.Exit(0)
+	}
 
-	// dog <task>
-	case len(os.Args) >= 2 && os.Args[1] != "help":
-		taskName := os.Args[1]
+	if a.version {
+		printVersion()
+		os.Exit(0)
+	}
 
-		tm, err := parser.LoadDogFile()
+	tm, err := parser.LoadDogFile()
+	if err != nil {
+		printNoValidDogfile()
+		os.Exit(1)
+	}
+
+	if a.taskName != "" {
+		runner, err := execute.NewRunner(tm, a.printFooter)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-
-		printTaskFooter := true // TODO: user can specify with a flag
-		runner, err := execute.NewRunner(tm, printTaskFooter)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-
-		runner.Run(taskName)
+		runner.Run(a.taskName)
+	} else {
+		printTasks(tm)
+		os.Exit(0)
 	}
 }


### PR DESCRIPTION
### Output examples for *help*, *version*, *task list* and *task footer*:

```
$ dog --help
Usage: dog
       dog [OPTIONS] TASK [ARGS]
       dog [--help] [--version]

Dog is a command line application that executes tasks.

Options:

  --footer       Print information footer after task execution (default)
  --no-footer    Don't print information footer after task execution
  -h, --help     Print this help
  -v, --version  Print version information and quit
```

```
$ dog --version
dog version: 0.0
```

```
$ dog 
build              Build dog binary
clean              Clean compiled binaries
run-test-dogfiles  Run all Tasks in testdata Dogfiles
```

```
$ dog clean
-- clean took 0.007s and finished with status code 0
```

### Errors that we are checking for invalid flags and task arguments:

```
$ dog -a
Error: -a is not a valid argument
```

```
$ dog --help --foo
Error: --help doesn't accept additional parameters
```

```
$ dog clean --foo
Error: --foo is not a valid argument
```

This closes #34 