### PR TITLE
Remove the idea of special tags from the SPEC

### DIFF
--- a/DOGFILE_SPEC.md
+++ b/DOGFILE_SPEC.md
@@ -126,18 +126,6 @@ Multiple tags are allowed.
     - dev
 ```
 
-Some special tags are provided. Hidden tasks are useful when we have tasks that are only executed as pre or post hooks but we don't want to show them in our task list.
-
-```yml
-  tags: hidden # Hide this task from the list
-```
-
-We can also tag our most important tasks to be highlighted at the top of the list in a separated group.
-
-```yml
-  tags: top # Show this task at the top of the list
-```
-
 ### env
 
 Default values for environment variables can be provided in the Dogfile. They can be modified at execution time.


### PR DESCRIPTION
*Hidden* tasks can be easily defined by avoiding the *description* directive

```yml
- task: visible-task
  description: Only this task will be shown in the task list
  run: echo visible

- task: hidden-task
  run: echo hidden
```

As for the *top* tag, it's better that the user decides how to organize/tag tasks than to force them to use special naming. Specially because the word *top* may make some sense in a CLI (vertical output) but not in a completely different UI.