### PR TITLE
Explicit event types and structural sharing

### DIFF
--- a/execute/executor.go
+++ b/execute/executor.go
@@ -84,8 +84,7 @@ func (ex *Executor) Exec(t *types.Task, eventsChan chan *types.Event) error {
 		return nil
 	}
 
-	startEvent := types.NewStartEvent(t.Name)
-	eventsChan <- startEvent
+	eventsChan <- types.NewStartEvent(t.Name)
 
 	statusCode := 0
 	if err := cmd.Wait(); err != nil {
@@ -99,7 +98,7 @@ func (ex *Executor) Exec(t *types.Task, eventsChan chan *types.Event) error {
 		}
 	}
 
-	eventsChan <- types.NewEndEvent(t.Name, statusCode, startEvent.Time)
+	eventsChan <- types.NewEndEvent(t.Name, statusCode)
 
 	return nil
 }

--- a/types/event.go
+++ b/types/event.go
@@ -2,16 +2,25 @@ package types
 
 import "time"
 
+type EventType int
+
+const (
+	StartEvent = EventType(iota + 1)
+	OutputEvent
+	EndEvent
+)
+
 type Event struct {
-	Name   string
-	Task   string
-	Time   time.Time
-	Extras map[string]interface{}
+	Type     EventType
+	Task     string
+	Time     time.Time
+	Body     []byte
+	ExitCode int
 }
 
 func NewStartEvent(taskName string) *Event {
 	return &Event{
-		Name: "start",
+		Type: StartEvent,
 		Task: taskName,
 		Time: time.Now(),
 	}
@@ -19,23 +28,18 @@ func NewStartEvent(taskName string) *Event {
 
 func NewOutputEvent(taskName string, body []byte) *Event {
 	return &Event{
-		Name: "output",
+		Type: OutputEvent,
 		Task: taskName,
 		Time: time.Now(),
-		Extras: map[string]interface{}{
-			"body": body,
-		},
+		Body: body,
 	}
 }
 
-func NewEndEvent(taskName string, statusCode int, startTime time.Time) *Event {
+func NewEndEvent(taskName string, exitCode int) *Event {
 	return &Event{
-		Name: "end",
-		Task: taskName,
-		Time: time.Now(),
-		Extras: map[string]interface{}{
-			"statusCode": statusCode,
-			"elapsed":    time.Since(startTime),
-		},
+		Type:     EndEvent,
+		Task:     taskName,
+		Time:     time.Now(),
+		ExitCode: exitCode,
 	}
 }


### PR DESCRIPTION
This refactor gives the event types explicit names and makes them share a typed structure that is the union of their independent structures. This is an improvement over sharing an untyped `map[string]interface{}`, and makes the code that actually uses it simpler.