### PR TITLE
Remove option to provide environment variables from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ Execute a task, printing elapsed time and status code
 
     dog -i taskname
 
-Execute a task providing environment variables
-
-    dog taskname -e VAR_NAME_1=value -e VAR_NAME_2=value
-
 ## What is a Dogfile?
 
 Dogfile is a specification that uses YAML to describe the tasks related to a project. We think that the Spec will be finished (no further breaking changes) by the v1.0.0 version of Dog.

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/dogtools/dog/execute"
 	"github.com/dogtools/dog/parser"
@@ -36,22 +35,6 @@ func main() {
 	if a.version {
 		printVersion()
 		os.Exit(0)
-	}
-
-	for a, v := range a.taskArgs {
-		switch a {
-		case "-e", "--env":
-			for _, e := range v {
-				pair := strings.SplitN(e, "=", 2)
-				if len(pair) != 2 {
-					fmt.Println("Error in env parameter", e)
-					os.Exit(1)
-				}
-				os.Setenv(pair[0], pair[1])
-			}
-		default:
-			fmt.Println("Argument not accepted", a, v)
-		}
 	}
 
 	tm, err := parser.LoadDogFile()


### PR DESCRIPTION
Removed option to provide environment variables from command line (-e, -env)

Closes #104 