### PR TITLE
Separate finding dogfiles from parsing them; fix #107 and #98

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -40,8 +40,8 @@ Dog is a command line application that executes tasks.
 Options:
 
   -i, --info       Print execution info (duration, statuscode) after task execution
-	-w, --workdir    Specify the working directory
-	-d, --directory  Specify the dogfiles' directory
+  -w, --workdir    Specify the working directory
+  -d, --directory  Specify the dogfiles' directory
   -h, --help       Print usage information and help
   -v, --version    Print version information`)
 }

--- a/cli.go
+++ b/cli.go
@@ -79,12 +79,13 @@ func parseArgs(args []string) (a userArgs, err error) {
 
 	// default values
 	a = userArgs{
-		help:     false,
-		workdir:  "",
-		version:  false,
-		info:     false,
-		taskName: "",
-		taskArgs: map[string][]string{},
+		help:      false,
+		workdir:   "",
+		directory: "",
+		version:   false,
+		info:      false,
+		taskName:  "",
+		taskArgs:  map[string][]string{},
 	}
 
 	skipArgument := false

--- a/cli.go
+++ b/cli.go
@@ -9,12 +9,13 @@ import (
 )
 
 type userArgs struct {
-	help     bool
-	workdir  string
-	version  bool
-	info     bool
-	taskName string
-	taskArgs map[string][]string
+	help      bool
+	workdir   string
+	directory string
+	version   bool
+	info      bool
+	taskName  string
+	taskArgs  map[string][]string
 }
 
 var knownFlags = [...]string{
@@ -22,6 +23,7 @@ var knownFlags = [...]string{
 	"-w", "--workdir",
 	"-h", "--help",
 	"-v", "--version",
+	"-d", "--directory",
 }
 
 func printVersion() {
@@ -37,10 +39,11 @@ Dog is a command line application that executes tasks.
 
 Options:
 
-  -i, --info     Print execution info (duration, statuscode) after task execution
-  -w, --workdir  Specify the working directory
-  -h, --help     Print usage information and help
-  -v, --version  Print version information`)
+  -i, --info       Print execution info (duration, statuscode) after task execution
+	-w, --workdir    Specify the working directory
+	-d, --directory  Specify the dogfiles' directory
+  -h, --help       Print usage information and help
+  -v, --version    Print version information`)
 }
 
 func printNoValidDogfile() {
@@ -123,6 +126,12 @@ func parseArgs(args []string) (a userArgs, err error) {
 		if arg == "--workdir" || arg == "-w" {
 			next := i + 1
 			a.workdir = args[next]
+			skipArgument = true
+		}
+
+		if arg == "--directory" || arg == "-d" {
+			next := i + 1
+			a.directory = args[next]
 			skipArgument = true
 		}
 

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	tm, err := parser.LoadDogFile()
+	tm, err := parser.LoadDogFile(a.directory)
 	if err != nil {
 		printNoValidDogfile()
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -46,6 +46,9 @@ func main() {
 	if a.workdir != "" {
 		tm[a.taskName].Workdir = a.workdir
 	}
+	if tm[a.taskName].Workdir == "" {
+		tm[a.taskName].Workdir = a.directory
+	}
 	if a.taskName != "" {
 		runner, err := execute.NewRunner(tm, a.info)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -43,13 +43,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	if a.workdir != "" {
-		tm[a.taskName].Workdir = a.workdir
-	}
-	if tm[a.taskName].Workdir == "" {
-		tm[a.taskName].Workdir = a.directory
-	}
 	if a.taskName != "" {
+		if tm[a.taskName] != nil {
+			if a.workdir != "" {
+				tm[a.taskName].Workdir = a.workdir
+			}
+			if tm[a.taskName].Workdir == "" {
+				tm[a.taskName].Workdir = a.directory
+			}
+		}
+
 		runner, err := execute.NewRunner(tm, a.info)
 		if err != nil {
 			fmt.Println(err)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
+	"path/filepath"
 	"regexp"
 
 	"github.com/dogtools/dog/types"
@@ -12,6 +14,7 @@ import (
 )
 
 var ErrMalformedStringArray = errors.New("Malformed strings array")
+var ErrNoDogfiles = errors.New("No dogfiles found")
 
 type task struct {
 	Name        string      `json:"task"`
@@ -86,45 +89,68 @@ func ParseDogfile(d []byte, tm types.TaskMap) (err error) {
 	return
 }
 
-// LoadDogFile finds a Dogfile in disk, parses YAML and returns a map.
-func LoadDogFile() (tm types.TaskMap, err error) {
+// FindDogFiles finds Dogfiles in disk, traversing directories up from the
+// given path until it finds a directory containing Dogfiles, and returns
+// their paths.
+func FindDogFiles(startPath string) (dogfilePaths []string, err error) {
 	const validDogfileName = "^(Dogfile|🐕)"
-	tm = make(types.TaskMap)
-	foundDogfile := false
-
-	files, err := ioutil.ReadDir(".")
+	currentPath, err := filepath.Abs(startPath)
 	if err != nil {
 		return
 	}
 
-	for _, file := range files {
-		var match bool
-		match, err = regexp.MatchString(validDogfileName, file.Name())
+	for {
+		var files []os.FileInfo
+		files, err = ioutil.ReadDir(currentPath)
 		if err != nil {
 			return
 		}
 
-		if match {
-			foundDogfile = true
-			var fileData []byte
-			fileData, err = ioutil.ReadFile(file.Name())
+		for _, file := range files {
+			var match bool
+			match, err = regexp.MatchString(validDogfileName, file.Name())
 			if err != nil {
 				return
 			}
 
-			if err = ParseDogfile(fileData, tm); err != nil {
-				return
+			if match {
+				dogfilePath := path.Join(currentPath, file.Name())
+				dogfilePaths = append(dogfilePaths, dogfilePath)
 			}
 		}
+
+		if len(dogfilePaths) > 0 {
+			return
+		}
+
+		nextPath := path.Dir(currentPath)
+		if nextPath == currentPath {
+			return
+		}
+		currentPath = nextPath
+	}
+}
+
+// LoadDogFile finds a Dogfile in disk, parses YAML and returns a map.
+func LoadDogFile() (tm types.TaskMap, err error) {
+	tm = make(types.TaskMap)
+	files, err := FindDogFiles(".")
+	if err != nil {
+		return
+	}
+	if len(files) == 0 {
+		err = ErrNoDogfiles
+		return
 	}
 
-	if !foundDogfile {
-		err = os.Chdir("..")
+	for _, file := range files {
+		var fileData []byte
+		fileData, err = ioutil.ReadFile(file)
 		if err != nil {
 			return
 		}
-		tm, err = LoadDogFile()
-		if err != nil {
+
+		if err = ParseDogfile(fileData, tm); err != nil {
 			return
 		}
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -14,7 +14,7 @@ import (
 )
 
 var ErrMalformedStringArray = errors.New("Malformed strings array")
-var ErrNoDogfiles = errors.New("No dogfiles found")
+var ErrNoDogfile = errors.New("No dogfile found")
 
 type task struct {
 	Name        string      `json:"task"`
@@ -143,7 +143,7 @@ func LoadDogFile(directory string) (tm types.TaskMap, err error) {
 		return
 	}
 	if len(files) == 0 {
-		err = ErrNoDogfiles
+		err = ErrNoDogfile
 		return
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -132,9 +132,13 @@ func FindDogFiles(startPath string) (dogfilePaths []string, err error) {
 }
 
 // LoadDogFile finds a Dogfile in disk, parses YAML and returns a map.
-func LoadDogFile() (tm types.TaskMap, err error) {
+func LoadDogFile(directory string) (tm types.TaskMap, err error) {
+	if directory == "" {
+		directory = "."
+	}
+
 	tm = make(types.TaskMap)
-	files, err := FindDogFiles(".")
+	files, err := FindDogFiles(directory)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This fixes #107 and separates finding the folder containing the dogfiles by walking up the filesystem from actually parsing said dogfiles. This also implements the `-d`/`--directory` flag (which was trivial after the refactoring) which closes #98.

@xsb @marc-gr @n-marshall thoughts?