### PR TITLE
Adding unit test to duration formatter

### DIFF
--- a/chain_test.go
+++ b/chain_test.go
@@ -1,0 +1,49 @@
+package dog
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatDurationReturnsProperlyFormattedString(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{
+			25*time.Hour + 59*time.Minute + 59*time.Second,
+			"25h59m59s",
+		},
+		{
+			1*time.Hour + 10*time.Minute,
+			"1h10m",
+		},
+		{
+			10 * time.Second,
+			"10s",
+		},
+		{
+			1*time.Second + 500*time.Millisecond,
+			"2s",
+		},
+		{
+			1*time.Second + 1*time.Millisecond,
+			"1s",
+		},
+		{
+			1 * time.Millisecond,
+			"0.001s",
+		},
+		{
+			200 * time.Nanosecond,
+			"0.000s",
+		},
+	}
+
+	for _, c := range cases {
+		actual := formatDuration(c.d)
+		if actual != c.want {
+			t.Errorf("Got time string: %q, but expected: %q", actual, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Test that helps to reproduce formatting bug.
```
--- FAIL: TestFormatDurationReturnsProperlyFormattedString (0.00s)
	chain_test.go:46: Got time string: "26h1560m93599s", but expected: "25h59m59s"
	chain_test.go:46: Got time string: "1h70m4200s", but expected: "1h10m"
```
Looks like duration is represented by every unit of measure: 1h10m == 70m.