### PR TITLE
Implemented 'go run' runner, now runCmd uses file extensions

### DIFF
--- a/DOGFILE_SPEC.md
+++ b/DOGFILE_SPEC.md
@@ -80,6 +80,7 @@ The following list of runners are supported:
 - ruby
 - perl
 - nodejs
+- go
 
 ### pre
 

--- a/chain.go
+++ b/chain.go
@@ -89,6 +89,8 @@ func (taskChain *TaskChain) Run(stdout, stderr io.Writer) error {
 			runner, err = run.NewPerlRunner(t.Code, t.Workdir, t.Env)
 		case "nodejs":
 			runner, err = run.NewNodejsRunner(t.Code, t.Workdir, t.Env)
+		case "go":
+			runner, err = run.NewGoRunner(t.Code, t.Workdir, t.Env)
 		default:
 			if t.Runner == "" {
 				return errors.New("Runner not specified")

--- a/run/run.go
+++ b/run/run.go
@@ -27,32 +27,79 @@ type Runner interface {
 
 // NewShRunner creates a system standard shell script runner.
 func NewShRunner(code string, workdir string, env []string) (Runner, error) {
-	return newCmdRunner("sh", code, workdir, env)
+	return newCmdRunner(runCmdProperties{
+		runner:        "sh",
+		fileExtension: ".sh",
+		code:          code,
+		workdir:       workdir,
+		env:           env,
+	})
 }
 
 // NewBashRunner creates a Bash runner.
 func NewBashRunner(code string, workdir string, env []string) (Runner, error) {
-	return newCmdRunner("bash", code, workdir, env)
+	return newCmdRunner(runCmdProperties{
+		runner:        "bash",
+		fileExtension: ".sh",
+		code:          code,
+		workdir:       workdir,
+		env:           env,
+	})
 }
 
 // NewPythonRunner creates a Python runner.
 func NewPythonRunner(code string, workdir string, env []string) (Runner, error) {
-	return newCmdRunner("python", code, workdir, env)
+	return newCmdRunner(runCmdProperties{
+		runner:        "python",
+		fileExtension: ".py",
+		code:          code,
+		workdir:       workdir,
+		env:           env,
+	})
 }
 
 // NewRubyRunner creates a Ruby runner.
 func NewRubyRunner(code string, workdir string, env []string) (Runner, error) {
-	return newCmdRunner("ruby", code, workdir, env)
+	return newCmdRunner(runCmdProperties{
+		runner:        "ruby",
+		fileExtension: ".rb",
+		code:          code,
+		workdir:       workdir,
+		env:           env,
+	})
 }
 
 // NewPerlRunner creates a Perl runner.
 func NewPerlRunner(code string, workdir string, env []string) (Runner, error) {
-	return newCmdRunner("perl", code, workdir, env)
+	return newCmdRunner(runCmdProperties{
+		runner:        "perl",
+		fileExtension: ".pl",
+		code:          code,
+		workdir:       workdir,
+		env:           env,
+	})
 }
 
 // NewNodejsRunner creates a Node.js runner.
 func NewNodejsRunner(code string, workdir string, env []string) (Runner, error) {
-	return newCmdRunner("node", code, workdir, env)
+	return newCmdRunner(runCmdProperties{
+		runner:        "node",
+		fileExtension: ".js",
+		code:          code,
+		workdir:       workdir,
+		env:           env,
+	})
+}
+
+// NewGoRunner creates a Go runner that uses 'go run'.
+func NewGoRunner(code string, workdir string, env []string) (Runner, error) {
+	return newCmdRunner(runCmdProperties{
+		runner:        "go run",
+		fileExtension: ".go",
+		code:          code,
+		workdir:       workdir,
+		env:           env,
+	})
 }
 
 // GetOutputs is a helper method that returns both stdout and stderr outputs

--- a/testdata/Dogfile-golang.yml
+++ b/testdata/Dogfile-golang.yml
@@ -1,0 +1,11 @@
+- task: go-println
+  description: Golang Println says hello
+  runner: go
+  code: |
+    package main
+    
+    import "fmt"
+    
+    func main() {
+        fmt.Println("Hello from Go!")
+    }


### PR DESCRIPTION
This change makes runCmd use file extensions on all cmd based runners. 

This also introduces the Go runner.

File extensions were required for `go run` to work, but it's nice to have them on all other runners.

Example:
```yml
- task: go-println
  description: Golang Println says hello
  runner: go
  code: |
    package main
    
    import "fmt"
    
    func main() {
        fmt.Println("Hello from Go!")
    }

```

This closes #115 