### PR TITLE
Proper constructors for library types

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -21,8 +21,18 @@ type TaskChain struct {
 	Tasks []*Task
 }
 
-// Generate creates the TaskChain for a specific task.
-func (taskChain *TaskChain) Generate(d Dogfile, task string) error {
+// NewTaskChain creates the task chain for a specific dogfile and task.
+func NewTaskChain(d Dogfile, task string) (taskChain TaskChain, err error) {
+	err = taskChain.generate(d, task)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// Generate recursively iterates over all tasks, including pre and post tasks for
+// each of them, and adds all of them into a task chain.
+func (taskChain *TaskChain) generate(d Dogfile, task string) error {
 
 	t, found := d.Tasks[task]
 	if !found {
@@ -53,7 +63,7 @@ func (taskChain *TaskChain) Generate(d Dogfile, task string) error {
 	return nil
 }
 
-// addToChain iterates over a list of pre or post tasks and adds them to the task chain.
+// addToChain adds found tasks into the task chain.
 func addToChain(taskChain *TaskChain, d Dogfile, tasks []string) error {
 	for _, name := range tasks {
 
@@ -62,7 +72,7 @@ func addToChain(taskChain *TaskChain, d Dogfile, tasks []string) error {
 			return fmt.Errorf("Task %q does not exist", name)
 		}
 
-		if err := taskChain.Generate(d, t.Name); err != nil {
+		if err := taskChain.generate(d, t.Name); err != nil {
 			return err
 		}
 	}

--- a/cmd/dog/main.go
+++ b/cmd/dog/main.go
@@ -30,8 +30,8 @@ func main() {
 	}
 
 	// parse dogfile
-	var d dog.Dogfile
-	if err = d.ParseFromDisk(a.directory); err != nil {
+	dogfile, err := dog.ParseFromDisk(a.directory)
+	if err != nil {
 		printNoValidDogfile()
 		os.Exit(1)
 	}
@@ -42,12 +42,12 @@ func main() {
 			dog.ProvideExtraInfo = true
 		}
 
-		if d.Tasks[a.taskName] != nil {
+		if dogfile.Tasks[a.taskName] != nil {
 			if a.workdir != "" {
-				d.Tasks[a.taskName].Workdir = a.workdir
+				dogfile.Tasks[a.taskName].Workdir = a.workdir
 			}
-			if d.Tasks[a.taskName].Workdir == "" {
-				d.Tasks[a.taskName].Workdir = a.directory
+			if dogfile.Tasks[a.taskName].Workdir == "" {
+				dogfile.Tasks[a.taskName].Workdir = a.directory
 			}
 		} else {
 			fmt.Println("Unknown task name:", a.taskName)
@@ -55,20 +55,20 @@ func main() {
 		}
 
 		// generate task chain
-		var tc dog.TaskChain
-		if err = tc.Generate(d, a.taskName); err != nil {
+		taskChain, err := dog.NewTaskChain(dogfile, a.taskName)
+		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
 
 		// run task chain
-		err = tc.Run(os.Stdout, os.Stderr)
+		err = taskChain.Run(os.Stdout, os.Stderr)
 		if err != nil {
 			os.Exit(2)
 		}
 
 	} else {
-		printTasks(d)
+		printTasks(dogfile)
 		os.Exit(0)
 	}
 }

--- a/examples/hello/hello.go
+++ b/examples/hello/hello.go
@@ -13,7 +13,7 @@ import (
 func main() {
 
 	// Define two tasks in the Dogfile format using YAML
-	dogfile := `
+	dogfileYAML := `
 - task: hello-dog
   description: Say Hello
   post: hello-world
@@ -25,23 +25,21 @@ func main() {
 `
 
 	// Parse Dogfile
-	var d dog.Dogfile
-	err := d.Parse([]byte(dogfile))
+	dogfile, err := dog.Parse([]byte(dogfileYAML))
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
 	// Generate task chain that starts with 'hello-dog' but include both tasks
-	var tc dog.TaskChain
-	err = tc.Generate(d, "hello-dog")
+	taskChain, err := dog.NewTaskChain(dogfile, "hello-dog")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
 	// Run task chain
-	err = tc.Run(os.Stdout, os.Stderr)
+	err = taskChain.Run(os.Stdout, os.Stderr)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(2)

--- a/examples/http-api/http-api.go
+++ b/examples/http-api/http-api.go
@@ -12,12 +12,13 @@ import (
 )
 
 // Dogfile object
-var d dog.Dogfile
+var dogfile dog.Dogfile
 
 func main() {
+	var err error
 
 	// Parse Dogfile from current path
-	err := d.ParseFromDisk(".")
+	dogfile, err = dog.ParseFromDisk(".")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -38,15 +39,14 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	taskName := r.URL.Path[1:]
 
 	// Generate task chain for the task named as the URL path
-	var tc dog.TaskChain
-	err := tc.Generate(d, taskName)
+	taskChain, err := dog.NewTaskChain(dogfile, taskName)
 	if err != nil {
 		fmt.Fprintf(w, "task chain generation failed: %s\n", err)
 		os.Exit(1)
 	}
 
 	// Run task chain, HTTP client receives info about how task finished
-	err = tc.Run(os.Stdout, os.Stderr)
+	err = taskChain.Run(os.Stdout, os.Stderr)
 	if err != nil {
 		fmt.Fprintf(w, "%s failed: %s\n", taskName, err)
 		os.Exit(2)

--- a/task.go
+++ b/task.go
@@ -53,8 +53,7 @@ func (t *Task) Validate() error {
 	var d Dogfile
 	d.Tasks[t.Name] = t
 
-	var tc TaskChain
-	if err := tc.Generate(d, t.Name); err != nil {
+	if _, err := NewTaskChain(d, t.Name); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
This should simplify the use of `dog` as a library, adding proper constructors to `dog.Dogfile` and `dog.TaskChain`.